### PR TITLE
Update Bot to fit newest GIDO server (weshine)

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -67,7 +67,11 @@ func Run() {
 	discord.AddHandler(handleCleanGidoInteraction)
 
 	// open session
-	discord.Open()
+	err = discord.Open()
+	if err != nil {
+		log.Fatal("Error opening connection,", err)
+		return
+	}
 	defer discord.Close() // close session, after function termination
 
 	// keep bot running untill there is NO os interruption (ctrl + C)

--- a/gido/request.go
+++ b/gido/request.go
@@ -21,7 +21,7 @@ func fetchWaitInfo() (WaitInfo, error) {
 	// get current timestamp in milliseconds
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	// construct the URL
-	url := fmt.Sprintf("http://vpn.weshine.com.tw:8088/WaitInfoWeb/WaitInfo_GIDOHandler.ashx?act=WaitInfo&DEP_CODE=吉哆火鍋百匯&Kind=a1&date=%s&_=%d", currentDate, timestamp)
+	url := fmt.Sprintf("https://vpn.weshine.com.tw:8089/WaitInfoWeb/WaitInfo_GIDOHandler.ashx?act=WaitInfo&DEP_CODE=吉哆火鍋百匯&Kind=a1&date=%s&_=%d", currentDate, timestamp)
 
 	// create an HTTP client with a timeout of 2 seconds
 	client := &http.Client{


### PR DESCRIPTION
# Pull Request: Fix Server Changes and Enhance Error Handling

## 📋 Summary
This PR contains two important fixes and improvements:
1. Fix connection issues caused by server configuration changes
2. Enhance Discord bot error handling mechanism

## 🚀 Change Type
- [x] Bug Fix
- [x] Refactor/Improvement
- [ ] New Feature
- [ ] Breaking Change
- [ ] Documentation Update

## 📝 Detailed Changes

### Fixes

#### 1. Server Endpoint Update (`gido/request.go`)
- **Issue**: The original HTTP endpoint `http://vpn.weshine.com.tw:8088` is no longer available
- **Solution**: Updated to new HTTPS endpoint `https://vpn.weshine.com.tw:8089`
- **Impact**: Fixed the issue where GIDO wait information could not be retrieved properly

```diff
- url := fmt.Sprintf("http://vpn.weshine.com.tw:8088/WaitInfoWeb/WaitInfo_GIDOHandler.ashx?act=WaitInfo&DEP_CODE=吉哆火鍋百匯&Kind=a1&date=%s&_=%d", currentDate, timestamp)
+ url := fmt.Sprintf("https://vpn.weshine.com.tw:8089/WaitInfoWeb/WaitInfo_GIDOHandler.ashx?act=WaitInfo&DEP_CODE=吉哆火鍋百匯&Kind=a1&date=%s&_=%d", currentDate, timestamp)
```

#### 2. Discord Connection Error Handling (`bot/bot.go`)
- **Issue**: Errors from `discord.Open()` method were not handled, potentially causing silent failures
- **Solution**: Added proper error handling and logging
- **Impact**: Improved application stability and debuggability

```diff
- discord.Open()
+ err = discord.Open()
+ if err != nil {
+     log.Fatal("Error opening connection,", err)
+     return
+ }
```

## 🔧 Technical Changes

### File Changes
- `gido/request.go`: 1 line changed (URL endpoint update)
- `bot/bot.go`: 5 lines added, 1 line deleted (error handling logic)

### Protocol Changes
- HTTP → HTTPS: Enhanced data transmission security
- Port change: 8088 → 8089

## 🚨 Important Notes

### Deployment Considerations
1. Ensure the new HTTPS endpoint `https://vpn.weshine.com.tw:8089` is accessible in the deployment environment
2. Check if firewall rules need to be updated to allow HTTPS connections on port 8089
3. Verify SSL certificate validity